### PR TITLE
Add IJCAI'22

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Statistics of acceptance rate for the main AI conferences
 |IJCAI'19 | 17.9% (850/4752) | - |
 |IJCAI'20 | 12.6% (592/4717) | - |
 |IJCAI'21 | 13.9% (587/4204) | - |
+|IJCAI'22 | 14.9% (679/4535) | - |
 
 ### Data Mining and Information Retrieval
 


### PR DESCRIPTION
The text in [1]'s photo says # submitted papers is `4537`; however, the number on the bar chart says `4535`. According to [2], `4535` looks correct.


## Ref: 

[1] https://twitter.com/oktie/status/1551851885442875393/photo/1
[2] https://aip.riken.jp/news/20220420_ijcai2022/