### PR TITLE
add ICML'23 paper distinctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Acceptance rates for the ~~major~~ top-tier AI-related conferences
 |ICML'20 | 21.8% (1088/4990) | - |
 |ICML'21 | 21.5% (1184/5513) (166 long talks, 1018 short talks) | - |
 |ICML'22 | 21.9% (1235/5630) (118 long talks, 1117 short talks) | - |
-|ICML'23 | 27.9% (1827/6538) | - |
+|ICML'23 | 27.9% (1827/6538) (158 live orals, 1669 virtual orals with posters) | - |
 |NeurIPS'14 | 24.7% (414/1678) | - |
 |NeurIPS'15 | 21.9% (403/1838) | - |
 |NeurIPS'16 | 23.6% (569/2403) | - |


### PR DESCRIPTION
ICML'23 changed from the classic short oral v.s. long oral distinction to the more common poster v.s. oral system.